### PR TITLE
Update Html.php

### DIFF
--- a/XF/BbCode/Renderer/Html.php
+++ b/XF/BbCode/Renderer/Html.php
@@ -12,7 +12,7 @@ class Html extends XFCP_Html
     {
         if (!is_array($option))
         {
-            if (strpos($option, '|') && \XF::options()->CMTV_Code_backComp)
+            if (strpos($option ?? '', '|') && \XF::options()->CMTV_Code_backComp)
             {
                 $strrstr = function ($h, $n, $before = false)
                 {


### PR DESCRIPTION
Fix [E_DEPRECATED] strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated